### PR TITLE
fix: force apt-get upgrade in Dockerfiles to mitigate CVEs in python:…

### DIFF
--- a/ecs-bedrock-agentcore-dev-autonomous-ws-solution/kiro-agentcore-runtime/Dockerfile
+++ b/ecs-bedrock-agentcore-dev-autonomous-ws-solution/kiro-agentcore-runtime/Dockerfile
@@ -1,7 +1,7 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
-RUN apt-get update && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \

--- a/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/Dockerfile
+++ b/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/Dockerfile
@@ -1,7 +1,7 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
-RUN apt-get update && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \

--- a/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/Dockerfile
+++ b/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/Dockerfile
@@ -1,7 +1,7 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
-RUN apt-get update && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \


### PR DESCRIPTION
…3.12-slim base

Add apt-get upgrade -y before apt-get install to force all system packages to their latest patched versions from Debian upstream, even when the ECR base image has not yet been rebuilt with the fixes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
