### PR TITLE
fix: standardize all container images on Amazon Linux 2023 + Python 3.13

### DIFF
--- a/ecs-bedrock-agent-solution/deployment-scripts/buildspecs/backend-buildspec.yml
+++ b/ecs-bedrock-agent-solution/deployment-scripts/buildspecs/backend-buildspec.yml
@@ -12,7 +12,7 @@ phases:
       - echo Build started on `date`
       - cd cloud-optimization-web-interfaces/cloud-optimization-web-interface
       - echo "Building Docker image..."
-      - docker build -t $ECR_REPOSITORY_URI:latest -t $ECR_REPOSITORY_URI:$IMAGE_TAG -f Dockerfile .
+      - docker build --pull --no-cache -t $ECR_REPOSITORY_URI:latest -t $ECR_REPOSITORY_URI:$IMAGE_TAG -f Dockerfile .
       - echo "Testing container startup..."
       - docker run --rm --name test-container $ECR_REPOSITORY_URI:latest python -c "import fastapi; print('FastAPI import successful')"
   post_build:
@@ -21,6 +21,8 @@ phases:
       - echo "Pushing images to ECR..."
       - docker push $ECR_REPOSITORY_URI:latest
       - docker push $ECR_REPOSITORY_URI:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $ECR_REPOSITORY_URI | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true
       - echo "Creating imagedefinitions.json..."
       - printf '[{"name":"backend","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
       - cat imagedefinitions.json

--- a/ecs-bedrock-agent-solution/ecs-backend/Dockerfile
+++ b/ecs-bedrock-agent-solution/ecs-backend/Dockerfile
@@ -1,12 +1,15 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 WORKDIR /build
-RUN dnf install -y python3.12 python3.12-pip shadow-utils && dnf clean all
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip shadow-utils && dnf clean all
 COPY requirements.txt .
-RUN python3.12 -m pip install --user --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir --upgrade pip && \
+    python3.13 -m pip install --user --no-cache-dir -r requirements.txt
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
-RUN dnf install -y python3.12 shadow-utils && dnf clean all && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 RUN groupadd -r app && useradd -r -g app app
 WORKDIR /app
 COPY --from=builder /root/.local /home/app/.local

--- a/ecs-bedrock-agentcore-dev-autonomous-ws-solution/deployment-scripts/buildspecs/agent-buildspec.yml
+++ b/ecs-bedrock-agentcore-dev-autonomous-ws-solution/deployment-scripts/buildspecs/agent-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building agent container...
       - cd kiro-agentcore-runtime
-      - docker build -t $ECR_REPO:latest .
+      - docker build --pull --no-cache -t $ECR_REPO:latest .
       - docker tag $ECR_REPO:latest $ECR_REPO:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing to ECR...
       - docker push $ECR_REPO:latest
       - docker push $ECR_REPO:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $ECR_REPO | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-dev-autonomous-ws-solution/deployment-scripts/buildspecs/backend-buildspec.yml
+++ b/ecs-bedrock-agentcore-dev-autonomous-ws-solution/deployment-scripts/buildspecs/backend-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building Docker image...
       - cd ecs-backend
-      - docker build -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
+      - docker build --pull --no-cache -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing Docker image...
       - docker push $REPOSITORY_URI:latest
       - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $REPOSITORY_URI | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-dev-autonomous-ws-solution/ecs-backend/deployment/Dockerfile
+++ b/ecs-bedrock-agentcore-dev-autonomous-ws-solution/ecs-backend/deployment/Dockerfile
@@ -1,10 +1,15 @@
-FROM public.ecr.aws/docker/library/python:3.11-slim AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 WORKDIR /build
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip && dnf clean all
 COPY requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir --upgrade pip && \
+    python3.13 -m pip install --user --no-cache-dir -r requirements.txt
 
-FROM public.ecr.aws/docker/library/python:3.11-slim
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 RUN groupadd -r app && useradd -r -g app app
 WORKDIR /app
 COPY --from=builder /root/.local /home/app/.local
@@ -13,5 +18,6 @@ RUN chown -R app:app /app
 USER app
 ENV PATH=/home/app/.local/bin:$PATH PYTHONPATH=/app PYTHONUNBUFFERED=1
 EXPOSE 8000
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ecs-bedrock-agentcore-dev-autonomous-ws-solution/kiro-agentcore-runtime/Dockerfile
+++ b/ecs-bedrock-agentcore-dev-autonomous-ws-solution/kiro-agentcore-runtime/Dockerfile
@@ -1,7 +1,9 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
-FROM public.ecr.aws/docker/library/python:3.12-slim
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip curl bash unzip coreutils tar gzip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \

--- a/ecs-bedrock-agentcore-longrun-solution/deployment-scripts/buildspecs/agent-buildspec.yml
+++ b/ecs-bedrock-agentcore-longrun-solution/deployment-scripts/buildspecs/agent-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building agent container...
       - cd kiro-agentcore-runtime
-      - docker build -t $ECR_REPO:latest .
+      - docker build --pull --no-cache -t $ECR_REPO:latest .
       - docker tag $ECR_REPO:latest $ECR_REPO:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing to ECR...
       - docker push $ECR_REPO:latest
       - docker push $ECR_REPO:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $ECR_REPO | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-longrun-solution/deployment-scripts/buildspecs/backend-buildspec.yml
+++ b/ecs-bedrock-agentcore-longrun-solution/deployment-scripts/buildspecs/backend-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building Docker image...
       - cd ecs-backend
-      - docker build -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
+      - docker build --pull --no-cache -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing Docker image...
       - docker push $REPOSITORY_URI:latest
       - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $REPOSITORY_URI | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-longrun-solution/ecs-backend/deployment/Dockerfile
+++ b/ecs-bedrock-agentcore-longrun-solution/ecs-backend/deployment/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:3.11-slim as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 WORKDIR /build
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip && dnf clean all
 COPY requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir --upgrade pip && \
+    python3.13 -m pip install --user --no-cache-dir -r requirements.txt
 
-FROM python:3.11-slim
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 RUN groupadd -r app && useradd -r -g app app
 WORKDIR /app
 COPY --from=builder /root/.local /home/app/.local
@@ -13,5 +18,6 @@ RUN chown -R app:app /app
 USER app
 ENV PATH=/home/app/.local/bin:$PATH PYTHONPATH=/app PYTHONUNBUFFERED=1
 EXPOSE 8000
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/Dockerfile
+++ b/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/Dockerfile
@@ -1,7 +1,9 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
-FROM public.ecr.aws/docker/library/python:3.12-slim
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip curl bash unzip coreutils tar gzip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \

--- a/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/buildspec.yml
+++ b/ecs-bedrock-agentcore-longrun-solution/kiro-agentcore-runtime/buildspec.yml
@@ -11,9 +11,11 @@ phases:
   build:
     commands:
       - echo Building ARM64 Docker image with kiro-cli installer
-      - docker build -t $ECR_REPO:latest .
+      - docker build --pull --no-cache -t $ECR_REPO:latest .
   post_build:
     commands:
       - echo Pushing to ECR
       - docker push $ECR_REPO:latest
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name kiro-agentcore --image-id imageTag=latest --region us-west-2 || true
       - echo "Done"

--- a/ecs-bedrock-agentcore-memory-solution/deployment-scripts/buildspecs/agent-buildspec.yml
+++ b/ecs-bedrock-agentcore-memory-solution/deployment-scripts/buildspecs/agent-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building agent container...
       - cd kiro-agentcore-runtime
-      - docker build -t $ECR_REPO:latest .
+      - docker build --pull --no-cache -t $ECR_REPO:latest .
       - docker tag $ECR_REPO:latest $ECR_REPO:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing to ECR...
       - docker push $ECR_REPO:latest
       - docker push $ECR_REPO:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $ECR_REPO | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-memory-solution/deployment-scripts/buildspecs/backend-buildspec.yml
+++ b/ecs-bedrock-agentcore-memory-solution/deployment-scripts/buildspecs/backend-buildspec.yml
@@ -9,10 +9,12 @@ phases:
     commands:
       - echo Building Docker image...
       - cd ecs-backend
-      - docker build -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
+      - docker build --pull --no-cache -t $REPOSITORY_URI:latest -f deployment/Dockerfile .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:
       - echo Pushing Docker image...
       - docker push $REPOSITORY_URI:latest
       - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $REPOSITORY_URI | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true

--- a/ecs-bedrock-agentcore-memory-solution/ecs-backend/deployment/Dockerfile
+++ b/ecs-bedrock-agentcore-memory-solution/ecs-backend/deployment/Dockerfile
@@ -1,10 +1,15 @@
-FROM public.ecr.aws/docker/library/python:3.11-slim AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 WORKDIR /build
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip && dnf clean all
 COPY requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir --upgrade pip && \
+    python3.13 -m pip install --user --no-cache-dir -r requirements.txt
 
-FROM public.ecr.aws/docker/library/python:3.11-slim
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 RUN groupadd -r app && useradd -r -g app app
 WORKDIR /app
 COPY --from=builder /root/.local /home/app/.local
@@ -13,5 +18,6 @@ RUN chown -R app:app /app
 USER app
 ENV PATH=/home/app/.local/bin:$PATH PYTHONPATH=/app PYTHONUNBUFFERED=1
 EXPOSE 8000
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/Dockerfile
+++ b/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/Dockerfile
@@ -1,7 +1,9 @@
 # Kiro CLI + MCP as AgentCore Runtime (ARM64)
-FROM public.ecr.aws/docker/library/python:3.12-slim
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl bash unzip coreutils && rm -rf /var/lib/apt/lists/*
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip curl bash unzip coreutils tar gzip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscli.zip && \

--- a/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/buildspec.yml
+++ b/ecs-bedrock-agentcore-memory-solution/kiro-agentcore-runtime-with-memory/buildspec.yml
@@ -11,9 +11,11 @@ phases:
   build:
     commands:
       - echo Building ARM64 Docker image with kiro-cli installer
-      - docker build -t $ECR_REPO:latest .
+      - docker build --pull --no-cache -t $ECR_REPO:latest .
   post_build:
     commands:
       - echo Pushing to ECR
       - docker push $ECR_REPO:latest
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name kiro-agentcore --image-id imageTag=latest --region us-west-2 || true
       - echo "Done"

--- a/ecs-bedrock-agentcore-runtime-solution/deployment-scripts/buildspecs/backend-buildspec.yml
+++ b/ecs-bedrock-agentcore-runtime-solution/deployment-scripts/buildspecs/backend-buildspec.yml
@@ -11,7 +11,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo "Building Docker image from ecs-backend..."
-      - docker build --platform linux/amd64 -t $ECR_REPOSITORY_URI:latest -t $ECR_REPOSITORY_URI:$IMAGE_TAG -f ecs-backend/deployment/agentcore.dockerfile ecs-backend/
+      - docker build --pull --no-cache --platform linux/amd64 -t $ECR_REPOSITORY_URI:latest -t $ECR_REPOSITORY_URI:$IMAGE_TAG -f ecs-backend/deployment/agentcore.dockerfile ecs-backend/
       - echo "Testing container startup..."
       - docker run --rm $ECR_REPOSITORY_URI:latest python -c "import fastapi; print('FastAPI import successful')"
   post_build:
@@ -20,6 +20,8 @@ phases:
       - echo "Pushing images to ECR..."
       - docker push $ECR_REPOSITORY_URI:latest
       - docker push $ECR_REPOSITORY_URI:$IMAGE_TAG
+      - echo "Starting ECR image scan..."
+      - aws ecr start-image-scan --repository-name $(echo $ECR_REPOSITORY_URI | awk -F/ '{print $NF}') --image-id imageTag=$IMAGE_TAG --region $AWS_DEFAULT_REGION || true
       - echo "Creating imagedefinitions.json..."
       - printf '[{"name":"backend","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
       - cat imagedefinitions.json

--- a/ecs-bedrock-agentcore-runtime-solution/ecs-backend/deployment/agentcore.dockerfile
+++ b/ecs-bedrock-agentcore-runtime-solution/ecs-backend/deployment/agentcore.dockerfile
@@ -19,17 +19,16 @@
 # Multi-stage build for AgentCore backend with Strands agent services and graceful degradation
 
 # Build stage - Install dependencies
-FROM python:3.11-slim as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as builder
 
 # Set build arguments
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies needed for building
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip python3.13-devel \
+    gcc gcc-c++ make curl git && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 
 # Create build directory
 WORKDIR /build
@@ -38,20 +37,16 @@ WORKDIR /build
 COPY requirements.txt .
 
 # Install Python dependencies to user directory
-RUN pip install --user --no-cache-dir --upgrade pip && \
-    pip install --user --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --user --no-cache-dir --upgrade pip && \
+    python3.13 -m pip install --user --no-cache-dir -r requirements.txt
 
 # Production stage - AgentCore runtime image
-FROM python:3.11-slim as production
-
-# Set production arguments
-ARG DEBIAN_FRONTEND=noninteractive
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as production
 
 # Install only runtime dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 
 # Create non-root user for security
 RUN groupadd -r agentcore && useradd -r -g agentcore agentcore

--- a/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-aws-api/Dockerfile
+++ b/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-aws-api/Dockerfile
@@ -1,37 +1,18 @@
-FROM public.ecr.aws/docker/library/python:3.11-slim
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 WORKDIR /app
 
-
-
 COPY requirements.txt requirements.txt
-# Install from requirements file
-RUN pip install -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir aws-opentelemetry-distro>=0.10.1
 
+ENV AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 DOCKER_CONTAINER=1
 
-
-
-RUN pip install aws-opentelemetry-distro>=0.10.1
-
-
-# Set AWS region environment variable
-
-ENV AWS_REGION=us-east-1
-ENV AWS_DEFAULT_REGION=us-east-1
-
-
-# Signal that this is running in Docker for host binding logic
-ENV DOCKER_CONTAINER=1
-
-# Create non-root user
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-EXPOSE 8080
-EXPOSE 8000
-
-# Copy entire project (respecting .dockerignore)
+EXPOSE 8080 8000
 COPY . .
-
-# Use the full module path
-
-CMD ["opentelemetry-instrument", "python", "-m", "main"]
+CMD ["opentelemetry-instrument", "python3", "-m", "main"]

--- a/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-aws-cost-optimization/Dockerfile
+++ b/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-aws-cost-optimization/Dockerfile
@@ -1,12 +1,12 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 WORKDIR /app
 
-RUN dnf install -y python3.12 python3.12-pip shadow-utils && dnf clean all && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
-
 COPY requirements.txt requirements.txt
-RUN python3.12 -m pip install --no-cache-dir -r requirements.txt
-RUN python3.12 -m pip install --no-cache-dir aws-opentelemetry-distro>=0.10.1
+RUN python3.13 -m pip install --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir aws-opentelemetry-distro>=0.10.1
 
 ENV AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 DOCKER_CONTAINER=1
 

--- a/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-wa-sec/Dockerfile
+++ b/ecs-bedrock-agentcore-runtime-solution/strands-agents/strands-wa-sec/Dockerfile
@@ -1,37 +1,18 @@
-FROM public.ecr.aws/docker/library/python:3.11-slim
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN dnf upgrade -y --security && \
+    dnf install -y python3.13 python3.13-pip shadow-utils && dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
 WORKDIR /app
 
-
-
 COPY requirements.txt requirements.txt
-# Install from requirements file
-RUN pip install -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir -r requirements.txt
+RUN python3.13 -m pip install --no-cache-dir aws-opentelemetry-distro>=0.10.1
 
+ENV AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 DOCKER_CONTAINER=1
 
-
-
-RUN pip install aws-opentelemetry-distro>=0.10.1
-
-
-# Set AWS region environment variable
-
-ENV AWS_REGION=us-east-1
-ENV AWS_DEFAULT_REGION=us-east-1
-
-
-# Signal that this is running in Docker for host binding logic
-ENV DOCKER_CONTAINER=1
-
-# Create non-root user
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-EXPOSE 8080
-EXPOSE 8000
-
-# Copy entire project (respecting .dockerignore)
+EXPOSE 8080 8000
 COPY . .
-
-# Use the full module path
-
-CMD ["opentelemetry-instrument", "python", "-m", "main"]
+CMD ["opentelemetry-instrument", "python3", "-m", "main"]


### PR DESCRIPTION
- Align all 11 Dockerfiles to public.ecr.aws/amazonlinux/amazonlinux:2023
- Install python3.13 via dnf (AL2023 native package)
- Add dnf upgrade -y --security for OS-level CVE patching
- Add --pull --no-cache to all docker build commands in buildspecs
- Add aws ecr start-image-scan post-push for CVE visibility
- mcp-servers Dockerfile unchanged (already digest-pinned python:3.13.alpine)

Single base image across the entire repo eliminates version drift and simplifies CVE tracking to one OS + one Python version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
