### PR TITLE
fix: guard WebSocket sends in _run_task against client disconnection

### DIFF
--- a/ecs-bedrock-agentcore-memory-solution/TODO.md
+++ b/ecs-bedrock-agentcore-memory-solution/TODO.md
@@ -1,0 +1,47 @@
+# Remediation TODO — sandbox-cloudops-xacct-0526
+
+Stack: `sandbox-cloudops-xacct-0526`
+URL: https://d44uvol1phu4p.cloudfront.net
+Date: 2026-05-28
+
+---
+
+## Immediate (before public demo)
+
+- [ ] **Enforce Cognito auth** on all `/api/*` and `/ws` routes — backend middleware
+- [ ] **Fix cross-account CFN link** — update HTML to reference `sandbox-cloudops-xacct-0526` instead of deleted `sandbox-longrun-0426`
+- [ ] **Add rate limiting** — per-IP or per-user throttle on ALB or backend
+- [ ] **Enable DEMO_MASK_OUTPUT=true** — mask account IDs/resource names in responses
+- [ ] **Clear task history** — purge DynamoDB of old tasks containing real billing/infra data
+
+## Short-term (stability)
+
+- [ ] **Fix WebSocket race condition** — guard against `websocket.send` after `websocket.close`
+- [ ] **ECS desired count ≥ 2** — backend redundancy
+- [ ] **AgentCore Runtime keep-warm** — scheduled warmup or provisioned concurrency
+- [ ] **Per-user task isolation** — use Cognito user ID as DynamoDB partition key instead of "default"
+- [ ] **Run agent as non-root** — add USER directive in Dockerfile
+
+## Long-term (production-ready)
+
+- [ ] **WAF on CloudFront** — geo-restrict, bot protection, request size limits
+- [ ] **HTTPS-only ALB** — ACM certificate + redirect HTTP→HTTPS
+- [ ] **Audit logging** — log all agent invocations to CloudTrail/S3
+- [ ] **Cost guardrails** — budget alarm + auto-disable if spend exceeds threshold
+- [ ] **Scope down agent permissions** — replace ReadOnlyAccess with specific service permissions
+
+## Bugs Found
+
+- [ ] Cross-account CFN quick-create link references deleted stack (`sandbox-longrun-0426`)
+- [ ] WebSocket error: `Unexpected ASGI message 'websocket.send', after sending 'websocket.close'`
+- [ ] All tasks stored under user "default" — no user isolation
+- [ ] Agent cold start ~90s — first request after idle always returns "(agent not ready)"
+
+## Security Exposures (if public)
+
+- No authentication on API endpoints
+- Account ID `256358067059` visible in config.js and responses
+- IAM role ARNs exposed in task error messages
+- Full billing breakdown and resource inventory accessible without auth
+- No rate limiting — Bedrock/Kiro API cost abuse possible
+- Agent has ReadOnlyAccess to entire account

--- a/ecs-bedrock-agentcore-memory-solution/ecs-backend/orchestrator/app.py
+++ b/ecs-bedrock-agentcore-memory-solution/ecs-backend/orchestrator/app.py
@@ -244,6 +244,17 @@ def create_orchestrator_app() -> FastAPI:
     return app
 
 
+async def _safe_send(ws: WebSocket, data: dict):
+    """Send JSON to WebSocket, gracefully handling client disconnection."""
+    try:
+        await ws.send_json(data)
+    except RuntimeError as e:
+        if "websocket.close" in str(e) or "already completed" in str(e):
+            logger.debug(f"Client disconnected, skipping send: {data.get('type', '')}")
+        else:
+            raise
+
+
 async def _run_task(task_id: str, user_input: str, ws: WebSocket, session: dict, user: str = "default", assume_role_arn: str = ""):
     """Execute AgentCore runtime invocation and push result."""
     task = next(t for t in session["tasks"] if t["id"] == task_id)
@@ -256,7 +267,7 @@ async def _run_task(task_id: str, user_input: str, ws: WebSocket, session: dict,
         task["completed"] = datetime.utcnow().isoformat()
         save_task(user, task)
         _save_session(session)
-        await ws.send_json({
+        await _safe_send(ws, {
             "type": "task_complete",
             "task_id": task_id,
             "brief": brief,
@@ -268,4 +279,4 @@ async def _run_task(task_id: str, user_input: str, ws: WebSocket, session: dict,
         task["completed"] = datetime.utcnow().isoformat()
         save_task(user, task)
         _save_session(session)
-        await ws.send_json({"type": "task_error", "task_id": task_id, "message": f"Error: {str(e)[:200]}"})
+        await _safe_send(ws, {"type": "task_error", "task_id": task_id, "message": f"Error: {str(e)[:200]}"})


### PR DESCRIPTION
Add _safe_send() helper that catches RuntimeError when the WebSocket is already closed (client disconnected during long-running agent task).

Only catches the specific 'websocket.close already sent' condition — unexpected RuntimeErrors are re-raised to surface actual bugs.

Task results are persisted to DynamoDB before the send attempt, so no data is lost when the client is gone.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
